### PR TITLE
Change DB environment variable name

### DIFF
--- a/3.5/run-database.sh
+++ b/3.5/run-database.sh
@@ -43,9 +43,9 @@ if [[ "$1" == "--initialize" ]]; then
     rabbitmqctl add_user $USERNAME $PASSPHRASE
 
     # The vhost is equivalent to the "db" in our case
-    rabbitmqctl add_vhost $DB
+    rabbitmqctl add_vhost $DATABASE
 
-    rabbitmqctl set_permissions -p $DB $USERNAME ".*" ".*" ".*"
+    rabbitmqctl set_permissions -p $DATABASE $USERNAME ".*" ".*" ".*"
     rabbitmqctl set_user_tags $USERNAME administrator
 
     rabbitmqctl delete_user guest

--- a/3.5/test/rabbitmq.bats
+++ b/3.5/test/rabbitmq.bats
@@ -7,7 +7,7 @@ setup() {
   mkdir "$RABBITMQ_MNESIA_BASE"
   cp -r /ssl /ssl-old
 
-  USERNAME=user PASSPHRASE=pass DB=db /usr/bin/wrapper --initialize  > /dev/null 2>&1
+  USERNAME=user PASSPHRASE=pass DATABASE=db /usr/bin/wrapper --initialize  > /dev/null 2>&1
 
   sleep 25
 


### PR DESCRIPTION
Fix typo where the environment variable is set to DB, instead of
DATABASE which is the name which is actually used internally.