### PR TITLE
Symlink generated certs

### DIFF
--- a/3.5/run-database.sh
+++ b/3.5/run-database.sh
@@ -8,7 +8,10 @@ set -e
 
 function generate_self_signed_certs {
     echo "Generating certificates"
-    cd /ssl/testca
+
+    cp -r /ssl/testca /var/db/testca
+    cd /var/db/testca
+
     mkdir certs private
     chmod 700 private
     echo 01 > serial
@@ -28,9 +31,9 @@ function generate_self_signed_certs {
     openssl ca -config openssl.cnf -in ../server/req.pem -out \
 	        ../server/cert.pem -notext -batch -days 10000 -extensions server_ca_extensions
 
-    mv cacert.pem /ssl
-    mv ../server/cert.pem /ssl
-    mv ../server/key.pem /ssl
+    ln -s /var/db/testca/cacert.pem /ssl/cacert.pem
+    ln -s /var/db/server/cert.pem /ssl/cert.pem
+    ln -s /var/db/server/key.pem /ssl/key.pem
 }
 
 if [[ "$1" == "--initialize" ]]; then

--- a/3.5/test/rabbitmq.bats
+++ b/3.5/test/rabbitmq.bats
@@ -7,7 +7,7 @@ setup() {
   mkdir "$RABBITMQ_MNESIA_BASE"
   cp -r /ssl /ssl-old
 
-  USERNAME=user PASSPHRASE=pass DATABASE=db /usr/bin/wrapper --initialize  > /dev/null 2>&1
+  USERNAME=user PASSPHRASE=pass DATABASE=db /usr/bin/wrapper --initialize > /dev/null 2>&1
 
   sleep 25
 
@@ -26,9 +26,13 @@ teardown() {
 
   wait $SCRIPT_PID
 
+  rm /ssl/cacert.pem
+  rm /ssl/cert.pem
+  rm /ssl/key.pem
+
+  rm -rf /var/db/testca
+  rm -rf /var/db/server
   rm -rf "$RABBITMQ_MNESIA_BASE"
-  rm -rf /ssl
-  mv /ssl-old /ssl
   export RABBITMQ_MNESIA_BASE="$OLD_RABBITMQ_MNESIA_BASE"
   unset OLD_RABBITMQ_MNESIA_BASE
 }


### PR DESCRIPTION
Symlink generated certs from volume container instead of generating
the certificate directly in the /ssl folder.