### PR TITLE
If available use certs found in environment

### DIFF
--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -12,12 +12,9 @@ ENV         PATH=$RABBITMQ_HOME/sbin:$PATH
 
 RUN         mkdir /srv && apk add --update curl tar gzip bash && \
             curl -Lk "https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v${RABBITMQ_VERSION//\./_}/rabbitmq-server-generic-unix-${RABBITMQ_VERSION}.tar.gz" > /srv/rabbitmq-server-generic-unix-${RABBITMQ_VERSION}.tar.gz && \
-            echo "http://dl-4.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
-            echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-            echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+            apk upgrade --update-cache && \
             apk add python erlang erlang erlang-mnesia erlang-public-key erlang-crypto erlang-ssl \
-                erlang-sasl erlang-asn1 erlang-inets erlang-os-mon erlang-xmerl erlang-eldap \
-                --update-cache --allow-untrusted && \
+                erlang-sasl erlang-asn1 erlang-inets erlang-os-mon erlang-xmerl erlang-eldap && \
             cd /srv && \
             tar -xzvf rabbitmq-server-generic-unix-${RABBITMQ_VERSION}.tar.gz && \
             rm -f rabbitmq-server-generic-unix-${RABBITMQ_VERSION}.tar.gz && \
@@ -29,6 +26,7 @@ RUN         mkdir /srv && apk add --update curl tar gzip bash && \
 COPY        openssl.cnf /ssl/testca/openssl.cnf
 COPY        rabbitmq.config /srv/rabbitmq_server-${RABBITMQ_VERSION}/etc/rabbitmq/
 COPY        run-database.sh /usr/bin/wrapper
+COPY        initialize-certs.sh /usr/bin/initialize-certs
 COPY        rabbitmqadmin /usr/local/bin/rabbitmqadmin
 COPY        rabbitmqadmin.conf /usr/local/bin/rabbitmqadmin.conf
 
@@ -36,7 +34,7 @@ ADD         test /tmp/test
 RUN         ln -s /var/db/testca/cacert.pem /ssl/cacert.pem && \
             ln -s /var/db/server/cert.pem /ssl/cert.pem && \
             ln -s /var/db/server/key.pem /ssl/key.pem && \
-            chmod a+x /usr/bin/wrapper /usr/local/bin/rabbitmqadmin && \
+            chmod a+x /usr/bin/wrapper /usr/local/bin/rabbitmqadmin /usr/bin/initialize-certs && \
             bats --tap /tmp/test && apk del --purge python
 EXPOSE      15671 5671
 VOLUME      ["$DATA_DIRECTORY"]

--- a/3.5/initialize-certs.sh
+++ b/3.5/initialize-certs.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+ssl_directory="/var/db/server"
+ssl_cert_file="${ssl_directory}/cert.pem"
+ssl_key_file="${ssl_directory}/key.pem"
+
+if [ -f "$ssl_cert_file" ] && [ -f "$ssl_key_file" ]; then
+    echo "Certs present on filesystem - using them"
+elif [ -n "$SSL_CERTIFICATE" ] && [ -n "$SSL_KEY" ]; then
+    echo "Taking certificate from environment"
+    echo -e "$SSL_KEY" > key.pem
+    echo -e "$SSL_CERTIFICATE" > cert.pem
+    echo -e "$SSL_CERTIFICATE" > cacert.pem
+
+    mkdir /var/db/server
+    mkdir /var/db/testca
+    mv key.pem $ssl_directory
+    mv cert.pem $ssl_directory
+    mv cacert.pem /var/db/testca
+else
+    [[ -n $1 ]] && name="$1" || name=$(hostname)
+
+    echo "Generating certificate with name $name"
+
+    cp -r /ssl/testca /var/db/testca
+    cd /var/db/testca
+
+    mkdir certs private
+    chmod 700 private
+    echo 01 > serial
+    touch index.txt
+
+    openssl req -x509 -config openssl.cnf -newkey rsa:2048 -days 10000 \
+        -out cacert.pem -outform PEM -subj /CN=MyTestCA -nodes
+    openssl x509 -in cacert.pem -out cacert.cer -outform DER
+
+    cd ..
+    mkdir server
+    cd server
+    openssl genrsa -out key.pem 2048
+    openssl req -new -key key.pem -out req.pem -days 10000 -outform PEM \
+            -subj /CN=${name}/O=server/ -nodes -batch
+    cd ../testca
+    openssl ca -config openssl.cnf -in ../server/req.pem -out \
+            ../server/cert.pem -notext -batch -days 10000 -extensions server_ca_extensions
+fi

--- a/3.5/run-database.sh
+++ b/3.5/run-database.sh
@@ -6,34 +6,8 @@ trap 'kill $(jobs -p)' EXIT
 # Die on error
 set -e
 
-function generate_self_signed_certs {
-    echo "Generating certificates"
-
-    cp -r /ssl/testca /var/db/testca
-    cd /var/db/testca
-
-    mkdir certs private
-    chmod 700 private
-    echo 01 > serial
-    touch index.txt
-
-    openssl req -x509 -config openssl.cnf -newkey rsa:2048 -days 10000 \
-        -out cacert.pem -outform PEM -subj /CN=MyTestCA/ -nodes
-    openssl x509 -in cacert.pem -out cacert.cer -outform DER
-
-    cd ..
-    mkdir server
-    cd server
-    openssl genrsa -out key.pem 2048
-    openssl req -new -key key.pem -out req.pem -days 10000 -outform PEM \
-	        -subj /CN=$(hostname)/O=server/ -nodes -batch
-    cd ../testca
-    openssl ca -config openssl.cnf -in ../server/req.pem -out \
-	        ../server/cert.pem -notext -batch -days 10000 -extensions server_ca_extensions
-}
-
 if [[ "$1" == "--initialize" ]]; then
-    generate_self_signed_certs
+    /usr/bin/initialize-certs
 
     rabbitmq-server &
 
@@ -53,6 +27,8 @@ if [[ "$1" == "--initialize" ]]; then
 elif [[ "$1" == "--client" ]]; then
     echo "This image does not support the --client option. Use rabbitmqadmin instead." && exit 1
 else
+    /usr/bin/initialize-certs
+
     echo "Launching RabbitMQ..."
 
     rabbitmq-server &

--- a/3.5/test/rabbitmq.bats
+++ b/3.5/test/rabbitmq.bats
@@ -1,25 +1,25 @@
 #!/usr/bin/env bats
 
-setup() {
+initialize_rabbitmq() {
   echo "test setup..."
   export OLD_RABBITMQ_MNESIA_BASE="$RABBITMQ_MNESIA_BASE"
   export RABBITMQ_MNESIA_BASE=/tmp/datadir
-  mkdir "$RABBITMQ_MNESIA_BASE"
+  rm -rf "$RABBITMQ_MNESIA_BASE" && mkdir "$RABBITMQ_MNESIA_BASE"
 
-  USERNAME=user PASSPHRASE=pass DATABASE=db /usr/bin/wrapper --initialize > /dev/null 2>&1
-
-  sleep 25
-
-  rabbitmq-server > /dev/null 2>&1 &
-
-  export SCRIPT_PID=$!
+  USERNAME=user PASSPHRASE=pass DATABASE=db /usr/bin/wrapper --initialize
 
   sleep 25
 }
 
+run_rabbitmq() {
+  rabbitmq-server &
+  export SCRIPT_PID=$!
+  sleep 25
+}
+
 teardown() {
-  rabbitmqctl stop_app  > /dev/null 2>&1
-  rabbitmqctl reset  > /dev/null 2>&1
+  rabbitmqctl stop_app
+  rabbitmqctl reset
 
   pkill -P $SCRIPT_PID
 
@@ -27,27 +27,34 @@ teardown() {
 
   rm -rf /var/db/testca
   rm -rf /var/db/server
-  rm -rf "$RABBITMQ_MNESIA_BASE"
   export RABBITMQ_MNESIA_BASE="$OLD_RABBITMQ_MNESIA_BASE"
   unset OLD_RABBITMQ_MNESIA_BASE
 }
 
 @test "It should bring up a working RabbitMQ instance" {
+    initialize_rabbitmq
+    run_rabbitmq
     run rabbitmqadmin -c /usr/local/bin/rabbitmqadmin.conf list queues vhost name
     [ "$status" -eq "0" ]
 }
 
 @test "It should be able to declare an exchange" {
+    initialize_rabbitmq
+    run_rabbitmq
     run rabbitmqadmin -c /usr/local/bin/rabbitmqadmin.conf declare exchange name=my-new-exchange type=fanout 
     [ "$status" -eq "0" ]
 }
 
 @test "It should be able to declare a queue" {
+    initialize_rabbitmq
+    run_rabbitmq
     run rabbitmqadmin -c /usr/local/bin/rabbitmqadmin.conf declare queue name=my-new-queue durable=false 
     [ "$status" -eq "0" ]
 }
 
 @test "It should be able to publish and retrieve a message" {
+    initialize_rabbitmq
+    run_rabbitmq
     run rabbitmqadmin -c /usr/local/bin/rabbitmqadmin.conf declare exchange name=my-new-exchange type=fanout 
     [ "$status" -eq "0" ]
     run rabbitmqadmin -c /usr/local/bin/rabbitmqadmin.conf declare queue name=my-new-queue durable=false
@@ -56,4 +63,29 @@ teardown() {
     [ "$status" -eq "0" ]
     run rabbitmqadmin -c /usr/local/bin/rabbitmqadmin.conf get queue=my-new-queue requeue=false
     [ "$status" -eq "0" ]
+}
+
+@test "It should auto-generate certs when none are provided" {
+    name="$(hostname)"
+    initialize_rabbitmq | grep "Generating certificate with name $name"
+    run_rabbitmq
+    curl -kv https://localhost:5671 2>&1 | grep $name
+}
+
+@test "It should prioritize ssl cert / key files from the environment" {
+    /usr/bin/initialize-certs bats-test | grep "Generating certificate with name bats-test"
+    export SSL_CERTIFICATE="$(cat "/var/db/server/cert.pem")"
+    export SSL_KEY="$(cat "/var/db/server/key.pem")"
+    rm -rf /var/db/testca
+    rm -rf /var/db/server
+    initialize_rabbitmq | grep "Taking certificate from environment"
+    run_rabbitmq
+    curl -kv https://localhost:5671 2>&1 | grep bats-test
+}
+
+@test "It should reuse existing ssl cert / key files" {
+    /usr/bin/initialize-certs bats-test | grep "Generating certificate with name bats-test"
+    initialize_rabbitmq | grep "Certs present on filesystem - using them"
+    run_rabbitmq
+    curl -kv https://localhost:5671 2>&1 | grep bats-test
 }


### PR DESCRIPTION
If `SSL_KEY` and `SSL_CERTIFICATE` are found in the environment, use them
instead of generating self-signed certificates.