### PR TITLE
Allow for persisting plugin configuration changes.

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -7,9 +7,9 @@ ENV         TAG=<%= ENV.fetch 'TAG' %> \
             RABBITMQ_LOGS=- \
             RABBITMQ_SASL_LOGS=-
 ENV         RABBITMQ_HOME=/srv/rabbitmq_server-${RABBITMQ_VERSION} \
-            PLUGINS_DIR=/srv/rabbitmq_server-${RABBITMQ_VERSION}/plugins \
-            ENABLED_PLUGINS_FILE=/srv/rabbitmq_server-${RABBITMQ_VERSION}/etc/rabbitmq/enabled_plugins
-ENV         PATH=$RABBITMQ_HOME/sbin:$PATH
+            PLUGINS_DIR=/srv/rabbitmq_server-${RABBITMQ_VERSION}/plugins
+ENV         RABBITMQ_ENABLED_PLUGINS_FILE=${DATA_DIRECTORY}/enabled_plugins \
+            PATH=$RABBITMQ_HOME/sbin:$PATH
 
 RUN         mkdir -p /srv && \
             cd /srv && \
@@ -23,12 +23,12 @@ RUN         mkdir -p /srv && \
                         erlang-sasl erlang-asn1 erlang-inets erlang-os-mon erlang-xmerl erlang-eldap xz bash && \
             tar -xvf "$ARCHIVE" && \
             rm -f "${ARCHIVE}" && \
-            touch "${RABBITMQ_HOME}/etc/rabbitmq/enabled_plugins" && \
+            mkdir "${DATA_DIRECTORY}" && \
             "${RABBITMQ_HOME}/sbin/rabbitmq-plugins" enable --offline rabbitmq_management && \
             "${RABBITMQ_HOME}/sbin/rabbitmq-plugins" enable --offline rabbitmq_shovel && \
             "${RABBITMQ_HOME}/sbin/rabbitmq-plugins" enable --offline rabbitmq_shovel_management && \
-            apk del --purge tar gzip && \
-            mkdir "${DATA_DIRECTORY}"
+            cp ${RABBITMQ_ENABLED_PLUGINS_FILE} /tmp/enabled_plugins_template && \
+            apk del --purge tar gzip
 
 COPY        etc/openssl.cnf /ssl/testca/openssl.cnf
 COPY        etc/rabbitmq.config.template /etc/rabbitmq.config.template

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -108,6 +108,10 @@ bootstrap_configuration () {
 
 if [[ "$1" == "--initialize" ]]; then
     /usr/bin/initialize-certs
+
+    # Start with the default plugins, but persist them on the data volume
+    cp /tmp/enabled_plugins_template "${DATA_DIRECTORY}/enabled_plugins"
+
     bootstrap_configuration "127.0.0.1"
 
     rabbitmq-server &

--- a/test-plugins.sh
+++ b/test-plugins.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+IMG="$1"
+TAG="$2"
+
+if [[ "$TAG" == "3.5" ]]; then
+  ADMIN_CMD="rabbitmqadmin -c /usr/local/bin/rabbitmqadmin.conf"
+elif [[ "$TAG" == "3.7" ]]; then
+  ADMIN_CMD="rabbitmqadmin --ssl-insecure -c /usr/local/bin/rabbitmqadmin.conf"
+fi
+
+DB_CONTAINER="rabbit"
+DATA_CONTAINER="${DB_CONTAINER}-data"
+RABBIT_USER="testuser"
+RABBIT_PASS="pass"
+
+function cleanup {
+  echo "Cleaning up"
+  docker rm -f "$DB_CONTAINER" "$DATA_CONTAINER" > /dev/null 2>&1 || true
+}
+
+wait_for_rabbitmq() {
+  docker exec -it "$DB_CONTAINER" apk add --update python &>/dev/null
+  for _ in $(seq 1 60); do
+    if docker exec -it "$DB_CONTAINER" $ADMIN_CMD list users &>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "RabbitMQ did not come online!"
+
+  return 1
+}
+
+trap cleanup EXIT
+cleanup
+
+echo "Creating data container"
+docker create --name "$DATA_CONTAINER" "$IMG" &> /dev/null
+
+echo "Initializing DB"
+docker run -it --rm\
+  -e USERNAME="$RABBIT_USER" -e PASSPHRASE="$RABBIT_PASS" -e DATABASE="db" \
+  --volumes-from "$DATA_CONTAINER" -h aptible \
+  "${IMG}" --initialize &> /dev/null
+
+echo "Starting DB"
+docker run -it --rm -d --name="$DB_CONTAINER" \
+  --volumes-from "$DATA_CONTAINER" -h aptible \
+  "${IMG}" &> /dev/null
+
+echo "Waiting for DB"
+wait_for_rabbitmq
+
+echo "Testing for existing plugin"
+docker exec -it "$DB_CONTAINER" rabbitmq-plugins list rabbitmq_management | grep '\[E\*\]' &> /dev/null
+
+echo "Enabling new plugin"
+docker exec -it "$DB_CONTAINER" rabbitmq-plugins enable rabbitmq_consistent_hash_exchange --online &> /dev/null
+
+echo "Testing for new plugin"
+docker exec -it "$DB_CONTAINER" rabbitmq-plugins list rabbitmq_consistent_hash_exchange | grep '\[E\*\]' &> /dev/null
+
+echo "Wiping out the database container"
+docker stop -t 10 "$DB_CONTAINER" &> /dev/null
+sleep 10
+
+
+echo "Starting DB again with the persistent volume"
+docker run -d --rm  --name="${DB_CONTAINER}" \
+  --volumes-from "$DATA_CONTAINER" -h aptible \
+  "${IMG}" &> /dev/null
+
+echo "Waiting for DB"
+wait_for_rabbitmq
+
+echo "Testing for existing plugin"
+docker exec -it "$DB_CONTAINER" rabbitmq-plugins list rabbitmq_management | grep '\[E\*\]' &> /dev/null
+
+echo "Testing for new plugin persistence"
+docker exec -it "$DB_CONTAINER" rabbitmq-plugins list rabbitmq_consistent_hash_exchange | grep '\[E\*\]' &> /dev/null
+
+echo "Done!"

--- a/test-plugins.sh
+++ b/test-plugins.sh
@@ -56,13 +56,13 @@ echo "Waiting for DB"
 wait_for_rabbitmq
 
 echo "Testing for existing plugin"
-docker exec -it "$DB_CONTAINER" rabbitmq-plugins list rabbitmq_management | grep '\[E\*\]' &> /dev/null
+docker exec -it "$DB_CONTAINER" rabbitmq-plugins list rabbitmq_management | grep -F '[E*]' &> /dev/null
 
 echo "Enabling new plugin"
 docker exec -it "$DB_CONTAINER" rabbitmq-plugins enable rabbitmq_consistent_hash_exchange --online &> /dev/null
 
 echo "Testing for new plugin"
-docker exec -it "$DB_CONTAINER" rabbitmq-plugins list rabbitmq_consistent_hash_exchange | grep '\[E\*\]' &> /dev/null
+docker exec -it "$DB_CONTAINER" rabbitmq-plugins list rabbitmq_consistent_hash_exchange | grep -F '[E*]' &> /dev/null
 
 echo "Wiping out the database container"
 docker stop -t 10 "$DB_CONTAINER" &> /dev/null
@@ -78,9 +78,9 @@ echo "Waiting for DB"
 wait_for_rabbitmq
 
 echo "Testing for existing plugin"
-docker exec -it "$DB_CONTAINER" rabbitmq-plugins list rabbitmq_management | grep '\[E\*\]' &> /dev/null
+docker exec -it "$DB_CONTAINER" rabbitmq-plugins list rabbitmq_management | grep -F '[E*]' &> /dev/null
 
 echo "Testing for new plugin persistence"
-docker exec -it "$DB_CONTAINER" rabbitmq-plugins list rabbitmq_consistent_hash_exchange | grep '\[E\*\]' &> /dev/null
+docker exec -it "$DB_CONTAINER" rabbitmq-plugins list rabbitmq_consistent_hash_exchange | grep -F '[E*]' &> /dev/null
 
 echo "Done!"

--- a/test.sh
+++ b/test.sh
@@ -12,11 +12,12 @@ docker run -it --rm --entrypoint "bash" "$IMG" \
 
 TESTS=(
   test-logging
+  test-plugins
  )
 
 for t in "${TESTS[@]}"; do
   echo "--- START ${t} ---"
-  "./${t}.sh" "$IMG"
+  "./${t}.sh" "$IMG" "$TAG"
   echo "--- OK    ${t} ---"
   echo
 done

--- a/test/rabbitmq.bats
+++ b/test/rabbitmq.bats
@@ -111,3 +111,17 @@ source "${BATS_TEST_DIRNAME}/test_helpers.sh"
     ! rabbit_client list users | grep -q guest
     rabbit_client list users | grep -q user
 }
+
+
+@test "It should have our default plugins enabled." {
+  start_rabbitmq
+  rabbitmq-plugins list rabbitmq_management | grep -F '[E*]'
+  rabbitmq-plugins list rabbitmq_shovel | grep -F '[E*]'
+  rabbitmq-plugins list rabbitmq_shovel_management | grep -F '[E*]'
+}
+
+@test "It should allow enabling plugins." {
+  start_rabbitmq
+  rabbitmq-plugins enable rabbitmq_consistent_hash_exchange --online
+  rabbitmq-plugins list rabbitmq_consistent_hash_exchange | grep -F '[E*]'
+}


### PR DESCRIPTION
Using `RABBITMQ_ENABLED_PLUGINS_FILE`, we can tell RabbitMQ where to find this file, and store it on the persistent volume.

https://www.rabbitmq.com/relocate.html

You can view available plugins with the command `rabbitmq-plugins list`

To enable (persistently) an available plugin, from within the database container run `rabbitmq-plugins enable $PLUGIN --online`. This will turn on the plugin, and it will persist after a restart.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptible/docker-rabbitmq/30)
<!-- Reviewable:end -->
