### PR TITLE
Version bump, revert erlang for RabbitMQ 3.5

### DIFF
--- a/3.5/config.mk
+++ b/3.5/config.mk
@@ -1,3 +1,5 @@
+export ALPINE_VERSION = 3.5
+
 export MAJOR = 3
 export MINOR = 5
 export REVISION = 8

--- a/3.7/config.mk
+++ b/3.7/config.mk
@@ -1,3 +1,5 @@
+export ALPINE_VERSION = 3.8
+
 export MAJOR = 3
 export MINOR = 7
 export REVISION = 12

--- a/3.7/config.mk
+++ b/3.7/config.mk
@@ -1,10 +1,10 @@
 export MAJOR = 3
 export MINOR = 7
-export REVISION = 9
+export REVISION = 12
 
 export RABBITMQ_VERSION = $(MAJOR).$(MINOR).$(REVISION)
 export RABBITMQ_PLUGINS = $(MAJOR).$(MINOR).x
-export RABBITMQ_SHA1SUM = 2294a3feb9baf7c972006fbd256a3e69f272f36b
+export RABBITMQ_SHA1SUM = 10237724b83246f83da5bdd42ff8d5aaea21c782
 export ARCHIVE_FORMAT = xz
 export RABBITMQ_DOWNLOAD_URL = https://github.com/rabbitmq/rabbitmq-server/releases/download/v$(RABBITMQ_VERSION)/rabbitmq-server-generic-unix-$(RABBITMQ_VERSION).tar.$(ARCHIVE_FORMAT)
 

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM        alpine:3.8
+FROM        alpine:<%= ENV.fetch 'ALPINE_VERSION' %>
 
 ENV         TAG=<%= ENV.fetch 'TAG' %> \
             RABBITMQ_VERSION=<%= ENV.fetch 'RABBITMQ_VERSION' %> \
@@ -19,7 +19,7 @@ RUN         mkdir -p /srv && \
               -fsSL "<%= ENV.fetch 'RABBITMQ_DOWNLOAD_URL' %>" \
               -o "${ARCHIVE}" && \
             echo "<%= ENV.fetch 'RABBITMQ_SHA1SUM' %>  ${ARCHIVE}" | sha1sum -c - && \
-            apk add --no-cache --update  erlang erlang erlang-mnesia erlang-public-key erlang-crypto erlang-ssl \
+            apk add --no-cache --update erlang erlang-mnesia erlang-public-key erlang-crypto erlang-ssl \
                         erlang-sasl erlang-asn1 erlang-inets erlang-os-mon erlang-xmerl erlang-eldap xz bash && \
             tar -xvf "$ARCHIVE" && \
             rm -f "${ARCHIVE}" && \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ startup time.
 ## Available Versions (Tags)
 
 * `latest`: Currently RabbitMQ 3.7
-* `3.7`: RabbitMQ 3.7.9
+* `3.7`: RabbitMQ 3.7.12
 * `3.5`: RabbitMQ 3.5.7
 
 ## Tests

--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,7 @@ IMG="$REGISTRY/$REPOSITORY:$TAG"
 
 echo "Unit Tests..."
 docker run -it --rm --entrypoint "bash" "$IMG" \
-  -c "apk add --update python >/dev/null && \
+  -c "apk add --update python ruby >/dev/null && \
       install-bats && \
       bats /tmp/test"
 

--- a/test/bunny.rb
+++ b/test/bunny.rb
@@ -1,0 +1,22 @@
+require "bunny"
+
+conn = Bunny.new('amqps://testuser:pass@localhost.aptible.in:5671/db', verify_peer: false)
+conn.start
+
+# open a channel
+ch = conn.create_channel
+
+# declare a queue
+q  = ch.queue("test1")
+
+# publish a message to the default econnchange which then gets routed to this queue
+q.publish("Test value")
+
+# fetch a message from the queue
+delivery_info, metadata, payload = q.pop
+
+if payload != "Test value"
+	raise "Queued message not found"
+end
+
+conn.stop

--- a/test/rabbitmq.bats
+++ b/test/rabbitmq.bats
@@ -2,9 +2,26 @@
 
 source "${BATS_TEST_DIRNAME}/test_helpers.sh"
 
+@test "RabbitMQ should use working/supported erlang version." {
+
+  if [ "$TAG" = "3.5" ]; then
+    apk info erlang | grep "erlang-19.1"
+  elif [ "$TAG" = "3.7" ]; then
+    apk info erlang | grep "erlang-20.3"
+  fi
+}
+
 @test "It should bring up a working RabbitMQ instance" {
-    start_rabbitmq
-    rabbit_client list queues vhost name
+  # According to rabbitmqadmin
+  start_rabbitmq
+  rabbit_client list queues vhost name
+
+  # Bunny caught errors pertaining to invalid/unsupported erlang
+  # version, which simply testing with rabbitmqadmin did not.
+  gem install bunny || echo ok
+  gem list bunny | grep bunny
+
+  ruby /tmp/test/bunny.rb
 }
 
 @test "It should be able to declare an exchange" {


### PR DESCRIPTION
Version bump 3.7.9 -> 3.7.12

https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.12
https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.11
https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.10

Also, this reverts to an "appropriate" version of Erlang for RabbitMQ 3.5, by way of Alpine 3.5.  This is the version of Erlang we were running previously, and despite being newer than the officially supported erlang version for RabbitMQ 3.5, we seem to have been okay with it for quite some time.

Two tests were added to be sure we don't have any regressions here:
* Explicitly check for the right version of erlang
* Use https://github.com/ruby-amqp/bunny to test for a working database, since it can catch the error we ran into, but `rabbitmqadmin` did not.

CC @krallin and @almathew 