### PR TITLE
Fix plugin file initialization.

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -44,7 +44,8 @@ RUN         VERSION="<%= ENV.fetch 'DELAYED_MESSAGE_EXCHANGE_VERSION' %>" \
          && echo "<%= ENV.fetch 'DELAYED_MESSAGE_EXCHANGE_SHA1SUM' %>  ${DOWNLOAD}" | sha1sum -c - \
          && (unzip "${DOWNLOAD}" || mv "${DOWNLOAD}" "${DOWNLOAD}.ez") \
          && mv "${DOWNLOAD}.ez" "/srv/rabbitmq_server-${RABBITMQ_VERSION}/plugins/" \
-         && rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange
+         && "${RABBITMQ_HOME}/sbin/rabbitmq-plugins" enable --offline rabbitmq_delayed_message_exchange \
+         && cp ${RABBITMQ_ENABLED_PLUGINS_FILE} /tmp/enabled_plugins_template
 
 RUN         ln -s /var/db/testca/cacert.pem /ssl/cacert.pem && \
             ln -s /var/db/server/cert.pem /ssl/cert.pem && \

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -104,13 +104,16 @@ bootstrap_configuration () {
   else
     export RABBITMQ_CONFIG_FILE="${baseConfig}.config"
   fi
+
+  # Make sure the default plugins are enabled and persisted
+  if [[ ! -f "${RABBITMQ_ENABLED_PLUGINS_FILE}" ]]; then
+    cp /tmp/enabled_plugins_template "${RABBITMQ_ENABLED_PLUGINS_FILE}"
+  fi
+
 }
 
 if [[ "$1" == "--initialize" ]]; then
     /usr/bin/initialize-certs
-
-    # Start with the default plugins, but persist them on the data volume
-    cp /tmp/enabled_plugins_template "${RABBITMQ_ENABLED_PLUGINS_FILE}"
 
     bootstrap_configuration "127.0.0.1"
 

--- a/test/rabbitmq.bats
+++ b/test/rabbitmq.bats
@@ -112,12 +112,14 @@ source "${BATS_TEST_DIRNAME}/test_helpers.sh"
     rabbit_client list users | grep -q user
 }
 
-
 @test "It should have our default plugins enabled." {
   start_rabbitmq
   rabbitmq-plugins list rabbitmq_management | grep -F '[E*]'
+  rabbitmq-plugins list rabbitmq_management_agent | grep -F '[e*]'
   rabbitmq-plugins list rabbitmq_shovel | grep -F '[E*]'
   rabbitmq-plugins list rabbitmq_shovel_management | grep -F '[E*]'
+  rabbitmq-plugins list rabbitmq_web_dispatch | grep -F '[e*]'
+  rabbitmq-plugins list rabbitmq_delayed_message_exchange | grep -F '[E*]'
 }
 
 @test "It should allow enabling plugins." {


### PR DESCRIPTION
The plugin file was moved to persistent storage but was only happening on initialization.  This meant that old databases moving to this image had no plugins enabled.

By conditionally migrating the plugin file template every run, we can be sure that:
* new databases get the default plugins
* old databases get the default plugins when upgraded to this image
* any plugins that subsequently get enabled persist