### PR TITLE
Avoid filling the disk.

### DIFF
--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -88,11 +88,16 @@ bootstrap_configuration () {
   local baseConfig
   baseConfig="$(mktemp)"
 
+  if [[ -n "${APTIBLE_CONTAINER_SIZE}" ]]; then
+    CONTAINER_RAM_KBYTES=$(( APTIBLE_CONTAINER_SIZE*1000*1000 ))
+  fi
+
   # shellcheck disable=SC2002
   cat "/etc/rabbitmq.config.template" \
     | sed "s:__SSL_DIR__:${SSL_DIR}:g" \
     | sed "s:__BIND_HOST__:${bindHost}:g"\
     | sed "s:__LOG_LEVEL__:${RABBIT_LOG_LEVEL:-info}:g"\
+    | sed "s:__APTIBLE_CONTAINER_SIZE__:${CONTAINER_RAM_KBYTES:-256000000}:g"\
     > "${baseConfig}"
 
   # RabbitMQ wants us to have a .config at the end of the filename.

--- a/etc/rabbitmq.config.template
+++ b/etc/rabbitmq.config.template
@@ -9,7 +9,8 @@
      {verify, verify_peer},
      {fail_if_no_peer_cert, false}
     ]},
-   {loopback_users, []}
+   {loopback_users, []},
+   {disk_free_limit, __APTIBLE_CONTAINER_SIZE__}
   ]},
  {rabbitmq_management,
   [{listener,

--- a/test/rabbitmq.bats
+++ b/test/rabbitmq.bats
@@ -112,7 +112,6 @@ source "${BATS_TEST_DIRNAME}/test_helpers.sh"
     rabbit_client list users | grep -q user
 }
 
-
 @test "It should have our default plugins enabled." {
   start_rabbitmq
   rabbitmq-plugins list rabbitmq_management | grep -F '[E*]'
@@ -124,4 +123,9 @@ source "${BATS_TEST_DIRNAME}/test_helpers.sh"
   start_rabbitmq
   rabbitmq-plugins enable rabbitmq_consistent_hash_exchange --online
   rabbitmq-plugins list rabbitmq_consistent_hash_exchange | grep -F '[E*]'
+}
+
+@test "It should set the disk free space limit based upon the container size" {
+    APTIBLE_CONTAINER_SIZE=2048 start_rabbitmq &> /tmp/rabbit.log
+    grep "Disk free limit set to 2048MB" /tmp/rabbit.log
 }


### PR DESCRIPTION
When free disk space drops below the configured limit, RabbitMQ will block producers and prevent memory-based messages from being paged to disk. This will reduce the likelihood of a crash due to disk space being exhausted, but will not eliminate it entirely.

If the disk alarm is set too low and messages are paged out rapidly, it is possible to run out of disk space and crash RabbitMQ in between disk space checks (at least 10 seconds apart). A more conservative approach is to set the limit to the same as the amount of memory installed on the system. So, I've set it to track APTIBLE_CONTAINER_SIZE, and to fall back to 256MB if needed (the default is a mere 50MB).